### PR TITLE
Adding bucket policy changes to support AWS Config service.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "default" {
 
     principals {
       type        = "Service"
-      identifiers = ["cloudtrail.amazonaws.com"]
+      identifiers = ["config.amazonaws.com", "cloudtrail.amazonaws.com"]
     }
 
     actions = [
@@ -58,6 +58,23 @@ data "aws_iam_policy_document" "default" {
         "bucket-owner-full-control",
       ]
     }
+  }
+
+  statement {
+    sid = "AWSConfigListBucket"
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${module.label.id}",
+    ]
   }
 
   statement {


### PR DESCRIPTION
## what
* Adding permissions for the EDO-183 story to enable AWS Config across Organization accounts using this bucket as the source for the S3 bucket delivery channel. AWS COnfig needs to be able to list buckets and needs to be added to the GetBicketAcl permission. 

## why
This is what is required to allow this S3 bucket to receive snapshots from the aws config service in multiple accounts.

## references
https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html
Under Granting AWS Config access to the Amazon S3 Bucket section.

