### PR TITLE
Updating for Terraform 13 and AWS 3.28 provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
   enabled     = var.enabled
   namespace   = var.namespace
   stage       = var.stage
@@ -99,13 +99,12 @@ data "aws_iam_policy_document" "default" {
 }
 
 module "s3_bucket" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.8.0"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.14.0"
   enabled                            = var.enabled
   namespace                          = var.namespace
   stage                              = var.stage
   environment                        = var.environment
   name                               = var.name
-  region                             = var.region
   acl                                = var.acl
   policy                             = join("", data.aws_iam_policy_document.default.*.json)
   force_destroy                      = var.force_destroy

--- a/variables.tf
+++ b/variables.tf
@@ -75,12 +75,6 @@ variable "lifecycle_tags" {
   default     = {}
 }
 
-variable "region" {
-  type        = string
-  description = "If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee"
-  default     = ""
-}
-
 variable "force_destroy" {
   type        = bool
   description = "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable"

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,18 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws   = "~> 2.0"
-    local = "~> 1.2"
-    null  = "~> 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.28.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 1.2"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 2.0"
+    }
   }
 }


### PR DESCRIPTION
Updating the s3 log storage module version to one supporting Terraform 13 and AWS 3.28 so that it will work with the latest platform repo changes for organization_config.